### PR TITLE
Lower version boundaries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "neos/neos": "~3.0.0"
+        "neos/neos": "~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As the Neos API is stable in a major release, the constraints can be set to support `3.*`