### PR TITLE
FEATURE: Update Neos dependency to 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "neos/neos": "~4.0"
+        "neos/neos": "~4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Tried to install the package on a Neos 4.1 and get some errors regarding dependencies.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for cvette/google-tag-manager ^3.0 -> satisfiable by cvette/google-tag-manager[v3.0].
    - Conclusion: remove symfony/console v3.2.8
    - Conclusion: don't install symfony/console v3.2.8
    - cvette/google-tag-manager v3.0 requires neos/neos ~4.0 -> satisfiable by neos/neos[4.0.0, 4.0.2, 4.0.3, 4.0.4, 4.0.5, 4.0.6, 4.0.7, 4.0.8, 4.0.9, 4.1.0, 4.1.1, 4.1.2, 4.1.3, 4.1.4, 4.1.5, 4.1.6, 4.1.7].
    - neos/neos 4.0.0 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.2 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.3 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.4 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.5 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.6 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.7 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.8 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.0.9 requires neos/flow ~5.0.0 -> satisfiable by neos/flow[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8].
    - neos/neos 4.1.0 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/neos 4.1.1 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/neos 4.1.2 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/neos 4.1.3 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/neos 4.1.4 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/neos 4.1.5 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/neos 4.1.6 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/neos 4.1.7 requires neos/flow ~5.1.0 -> satisfiable by neos/flow[5.1.0, 5.1.1, 5.1.2].
    - neos/flow 5.0.0 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.1 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.2 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.3 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.4 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.5 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.6 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.7 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.0.8 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.1.0 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.1.1 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - neos/flow 5.1.2 requires symfony/yaml ~4.0.0 -> satisfiable by symfony/yaml[v4.0.0, v4.0.1, v4.0.10, v4.0.11, v4.0.12, v4.0.13, v4.0.14, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7, v4.0.8, v4.0.9].
    - symfony/yaml v4.0.0 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.1 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.10 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.11 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.12 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.13 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.14 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.2 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.3 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.4 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.5 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.6 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.7 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.8 conflicts with symfony/console[v3.2.8].
    - symfony/yaml v4.0.9 conflicts with symfony/console[v3.2.8].
    - Installation request for symfony/console (locked at v3.2.8) -> satisfiable by symfony/console[v3.2.8].
```